### PR TITLE
feat: add Docker support with multi-stage build system

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,90 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Documentation
+*.md
+!README.md
+docs/
+*.rst
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+temp/
+
+# Cache directories
+.cache/
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+.ruff_cache/
+.tox/
+
+# Docker
+Dockerfile*
+docker-compose*
+.dockerignore
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+
+# Local development
+.env.local
+.env.*.local

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,125 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-base:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base
+        tags: |
+          type=ref,event=branch
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Check if base image exists
+      id: check-base
+      env:
+        ALL_TAGS: ${{ steps.meta.outputs.tags }}
+      run: |
+        TAG_TO_CHECK=$(echo "$ALL_TAGS" | head -n 1)
+        echo "Checking specific tag: $TAG_TO_CHECK"
+        if docker manifest inspect "$TAG_TO_CHECK" > /dev/null; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+          echo "✅ Base image exists."
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+          echo "⚠️ Base image not found or check failed."
+        fi
+
+    - name: Build and push base image
+      if: steps.check-base.outputs.exists == 'false' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.base
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+
+  build-runtime:
+    runs-on: ubuntu-latest
+    needs: build-base
+    if: always() && (needs.build-base.result == 'success' || needs.build-base.result == 'skipped')
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata for runtime
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Extract metadata for base
+      id: meta-base
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base
+        tags: |
+          type=raw,value=latest
+
+    - name: Build and push runtime image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.runtime
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          BASE_IMAGE=${{ steps.meta-base.outputs.tags }}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,57 @@
+# Docker
+
+This project uses a multi-stage Docker build system with a base image containing pre-compiled Typst documentation for faster builds.
+
+## Quick Start
+
+```bash
+# Pull and run the pre-built image
+docker run --rm -i ghcr.io/johannesbrandenburger/typst-mcp:latest
+```
+
+## Building
+
+### Using the build script
+
+```bash
+# Build both base and runtime images
+./build.sh
+
+# Build only runtime image (for code changes)
+./build.sh runtime
+
+# Build only base image (when docs change)
+./build.sh base
+
+# Run the container
+./build.sh run
+```
+
+### Manual build
+
+```bash
+# Build base image with Typst documentation
+docker build -f Dockerfile.base -t ghcr.io/johannesbrandenburger/typst-mcp-base:latest .
+
+# Build runtime image
+docker build -f Dockerfile.runtime -t ghcr.io/johannesbrandenburger/typst-mcp:latest .
+```
+
+## Docker Compose
+
+```yaml
+version: '3.8'
+services:
+  typst-mcp:
+    image: ghcr.io/johannesbrandenburger/typst-mcp:latest
+    stdin_open: true
+    tty: false
+    restart: unless-stopped
+```
+
+## Architecture
+
+- **Base image**: Contains pre-compiled Typst documentation (built from Rust nightly)
+- **Runtime image**: Contains the MCP server (built from Python slim, uses base image)
+
+The base image only needs rebuilding when Typst documentation changes, making runtime builds much faster.

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,31 @@
+# Base image with pre-compiled Typst documentation
+# This image only needs to be rebuilt when Typst documentation changes
+FROM rustlang/rust:nightly-slim
+
+# Install system dependencies for typst-docs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Install pkg-config for Rust dependencies
+    pkg-config \
+    # Install libssl-dev for Rust dependencies
+    libssl-dev \
+    # Install ca-certificates for HTTPS downloads
+    ca-certificates \
+    # Install git for cloning typst repository
+    git \
+    # Clean up apt caches to reduce image size
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone typst repository with all optimizations and generate docs
+RUN git clone --depth 1 --single-branch --no-tags https://github.com/typst/typst.git /tmp/typst && \
+    cd /tmp/typst && \
+    cargo run --package typst-docs -- --assets-dir /usr/local/share/typst-docs --out-file /usr/local/share/typst-docs/main.json && \
+    rm -rf /tmp/typst
+
+# Set labels for the base image
+LABEL org.opencontainers.image.title="Typst MCP Base"
+LABEL org.opencontainers.image.description="Base image with pre-compiled Typst documentation"
+LABEL org.opencontainers.image.source="https://github.com/bapttf/typst-mcp"
+
+# Default command to show docs are ready
+CMD ["ls", "-la", "/usr/local/share/typst-docs/"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,0 +1,78 @@
+# Runtime image using pre-built base with Typst documentation
+# Build the base image first: docker build -f Dockerfile.base -t typst-mcp-base .
+ARG BASE_IMAGE=ghcr.io/bapttf/typst-mcp-base:latest
+FROM ${BASE_IMAGE} AS base
+
+# Python builder stage
+FROM python:3.12-slim AS python-builder
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_CACHE_DIR=/tmp/uv-cache
+
+# Install uv for Python package management
+RUN pip install --no-cache-dir uv
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install Python dependencies
+RUN uv sync --frozen --no-dev
+
+# Final runtime image
+FROM python:3.12-slim AS runtime
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_CACHE_DIR=/tmp/uv-cache
+
+# Install only runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Install pandoc for LaTeX to Typst conversion
+    pandoc \
+    # Install ca-certificates for HTTPS downloads
+    ca-certificates \
+    # Install curl for downloading typst binary
+    curl \
+    # Install xz-utils for extracting typst binary
+    xz-utils \
+    # Clean up apt caches to reduce image size
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv for Python package management
+RUN pip install --no-cache-dir uv
+
+# Download and install pre-built typst binary
+RUN TYPST_VERSION=$(curl -s https://api.github.com/repos/typst/typst/releases/latest | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4) && \
+    curl -L "https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" | tar -xJ && \
+    mv typst-x86_64-unknown-linux-musl/typst /usr/local/bin/typst && \
+    rm -rf typst-x86_64-unknown-linux-musl
+
+# Set working directory
+WORKDIR /app
+
+# Copy Python dependencies from python-builder stage
+COPY --from=python-builder /app/.venv /app/.venv
+
+# Copy pre-compiled Typst documentation from base image
+COPY --from=base /usr/local/share/typst-docs /app/typst-docs
+
+# Copy application code
+COPY server.py ./
+COPY typst-docs-json-schema.json ./
+
+# Create non-root user for security
+RUN useradd --create-home --shell /bin/bash typst && \
+    chown -R typst:typst /app && \
+    mkdir -p /tmp/uv-cache && \
+    chown -R typst:typst /tmp/uv-cache
+USER typst
+
+# Set entrypoint
+ENTRYPOINT ["uv", "run", "python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ The server provides the following tools:
 
 ## Running the Server
 
+### Local Installation
+
 Execute the server script:
 
 ```bash
@@ -59,6 +61,201 @@ mcp install server.py
 Or use the new agent mode in VS Code:
 
 [Agent mode: available to all users and supports MCP](https://code.visualstudio.com/blogs/2025/04/07/agentMode)
+
+### Docker
+
+For Docker installation and usage, see [DOCKER.md](DOCKER.md) for detailed build information and instructions.
+
+## Platform Configuration
+
+This MCP server can be integrated with various AI coding platforms. Below are configuration instructions for popular platforms:
+
+### Claude Desktop
+
+Add the following to your Claude Desktop configuration file (`claude_desktop_config.json`):
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`  
+**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+Or for local installation:
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+### Cursor
+
+Create `.cursor/mcp.json` in your project root for project-specific configuration:
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+Or create `~/.cursor/mcp.json` for global configuration. For local installation:
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "python",
+      "args": ["/path/to/typst-mcp/server.py"]
+    }
+  }
+}
+```
+
+### Roo Code
+
+Create `.roo/mcp.json` in your project root for project-specific configuration:
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+Or edit global settings via Roo Code MCP settings view. For local installation:
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "python",
+      "args": ["/path/to/typst-mcp/server.py"]
+    }
+  }
+}
+```
+
+### OpenCode
+
+Create or edit the `opencode.json` file in your project root:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "typst": {
+      "type": "local",
+      "command": ["docker", "run", "--rm", "-i", 
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ],
+      "enabled": true
+    }
+  }
+}
+```
+
+For local installation:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "typst": {
+      "type": "local",
+      "command": ["python", "/path/to/typst-mcp/server.py"],
+      "enabled": true
+    }
+  }
+}
+```
+
+### Claude Code
+
+Configure MCP servers in your Claude Code settings file (`~/.claude/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+Or for local installation:
+
+```json
+{
+  "mcpServers": {
+    "typst": {
+      "command": "python",
+      "args": ["/path/to/typst-mcp/server.py"]
+    }
+  }
+}
+```
+
+### VS Code with Agent Mode
+
+VS Code's Agent Mode has native MCP support (no extension required):
+
+1. Enable Agent Mode in VS Code settings (`chat.agent.enabled`)
+2. Create `.vscode/mcp.json` in your workspace:
+
+```json
+{
+  "servers": {
+    "typst": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "ghcr.io/johannesbrandenburger/typst-mcp:latest"
+      ]
+    }
+  }
+}
+```
+
+For global configuration, add to your user profile via **MCP: Open User Configuration** command.
 
 ## JSON Schema of the Typst Documentation
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Typst MCP Docker Build Script
+# This script helps build the base and runtime images separately
+
+set -e
+
+# Allow custom registry via environment variable
+REGISTRY="${TYPST_MCP_REGISTRY:-ghcr.io/johannesbrandenburger/typst-mcp}"
+
+echo "🏗️  Typst MCP Docker Build Script"
+echo "================================="
+
+# Function to build base image
+build_base() {
+    echo "📚 Building base image with Typst documentation..."
+    docker build -f Dockerfile.base -t ${REGISTRY}-base:latest .
+    echo "✅ Base image built successfully!"
+}
+
+# Function to build runtime image
+build_runtime() {
+    echo "🚀 Building runtime image..."
+    docker build -f Dockerfile.runtime --build-arg BASE_IMAGE=${REGISTRY}-base:latest -t ${REGISTRY}:latest .
+    echo "✅ Runtime image built successfully!"
+}
+
+# Function to build both images
+build_all() {
+    echo "🏗️  Building both base and runtime images..."
+    build_base
+    build_runtime
+}
+
+# Function to push images
+push_images() {
+    echo "📤 Pushing images to registry..."
+    docker push ${REGISTRY}-base:latest
+    docker push ${REGISTRY}:latest
+    echo "✅ Images pushed successfully!"
+}
+
+# Function to run the container
+run_container() {
+    echo "🏃 Running Typst MCP container..."
+    docker run --rm -i ${REGISTRY}:latest
+}
+
+# Function to show help
+show_help() {
+    echo "Usage: $0 [command]"
+    echo ""
+    echo "Commands:"
+    echo "  base     - Build only the base image with Typst docs"
+    echo "  runtime  - Build only the runtime image"
+    echo "  all      - Build both base and runtime images (default)"
+    echo "  push     - Push both images to registry"
+    echo "  run      - Run the Typst MCP container"
+    echo "  help     - Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0              # Build both images"
+    echo "  $0 base         # Build only base image"
+    echo "  $0 runtime      # Build only runtime image"
+    echo "  $0 push         # Push images to registry"
+    echo "  $0 run          # Run the container"
+}
+
+# Main script logic
+case "${1:-all}" in
+    "base")
+        build_base
+        ;;
+    "runtime")
+        build_runtime
+        ;;
+    "all")
+        build_all
+        ;;
+    "push")
+        push_images
+        ;;
+    "run")
+        run_container
+        ;;
+    "help"|"-h"|"--help")
+        show_help
+        ;;
+    *)
+        echo "❌ Unknown command: $1"
+        show_help
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR adds initial Docker support with an optimized multi-stage build system:

- Multi-stage builds: Separate base image with pre-compiled Typst documentation and runtime image with the MCP server
- GitHub Actions CI/CD: Automated builds and publishing to GitHub Container Registry
- Build script: Easy development workflow with options for building base/runtime images separately
- Documentation: Updated README with Docker installation instructions and platform configurations

The base image contains pre-compiled Typst documentation and only needs rebuilding when docs change, while the runtime image builds quickly for code changes.

---

I know this is a niche project and people who find this are probably capable of getting it working locally, but I think Docker makes it both safer and easier for everyone. Hopefully this helps others skip the setup and just start using this Typst MCP with their AI agent right away.

