### PR TITLE
Multiplatform docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,13 +14,72 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-base:
+  # ============================================
+  # BASE IMAGE - Check if rebuild needed
+  # ============================================
+  check-base:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      should-build: ${{ steps.check.outputs.should-build }}
+
+    steps:
+    - name: Check if base image needs rebuild
+      id: check
+      run: |
+        # Force rebuild on workflow_dispatch or release
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ github.event_name }}" == "release" ]]; then
+          echo "should-build=true" >> $GITHUB_OUTPUT
+          echo "Force rebuild triggered by ${{ github.event_name }}"
+          exit 0
+        fi
+        
+        # Check if multi-platform base image exists with both platforms
+        TAG_TO_CHECK="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base:latest"
+        if docker manifest inspect "$TAG_TO_CHECK" > /dev/null 2>&1; then
+          MANIFEST=$(docker manifest inspect "$TAG_TO_CHECK" 2>/dev/null || echo "{}")
+          HAS_AMD64=$(echo "$MANIFEST" | grep -q '"architecture": "amd64"' && echo "true" || echo "false")
+          HAS_ARM64=$(echo "$MANIFEST" | grep -q '"architecture": "arm64"' && echo "true" || echo "false")
+          
+          if [[ "$HAS_AMD64" == "true" ]] && [[ "$HAS_ARM64" == "true" ]]; then
+            echo "should-build=false" >> $GITHUB_OUTPUT
+            echo "Base image exists with both platforms"
+          else
+            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "Base image missing one or more platforms (amd64: $HAS_AMD64, arm64: $HAS_ARM64)"
+          fi
+        else
+          echo "should-build=true" >> $GITHUB_OUTPUT
+          echo "Base image not found"
+        fi
+
+  # ============================================
+  # BASE IMAGE - Build per platform
+  # ============================================
+  build-base:
+    needs: check-base
+    if: needs.check-base.outputs.should-build == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
 
     steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -35,7 +94,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Extract metadata
+    - name: Extract metadata for base
       id: meta
       uses: docker/metadata-action@v5
       with:
@@ -44,40 +103,107 @@ jobs:
           type=ref,event=branch
           type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Check if base image exists
-      id: check-base
-      env:
-        ALL_TAGS: ${{ steps.meta.outputs.tags }}
-      run: |
-        TAG_TO_CHECK=$(echo "$ALL_TAGS" | head -n 1)
-        echo "Checking specific tag: $TAG_TO_CHECK"
-        if docker manifest inspect "$TAG_TO_CHECK" > /dev/null; then
-          echo "exists=true" >> $GITHUB_OUTPUT
-          echo "✅ Base image exists."
-        else
-          echo "exists=false" >> $GITHUB_OUTPUT
-          echo "⚠️ Base image not found or check failed."
-        fi
-
-    - name: Build and push base image
-      if: steps.check-base.outputs.exists == 'false' || github.event_name == 'workflow_dispatch' || github.event_name == 'release'
-      uses: docker/build-push-action@v5
+    - name: Build and push base image by digest
+      id: build
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile.base
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
+        platforms: ${{ matrix.platform }}
         labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
 
-  build-runtime:
+    - name: Export digest
+      if: github.event_name != 'pull_request'
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      if: github.event_name != 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-base-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # ============================================
+  # BASE IMAGE - Merge manifests
+  # ============================================
+  merge-base:
     runs-on: ubuntu-latest
     needs: build-base
-    if: always() && (needs.build-base.result == 'success' || needs.build-base.result == 'skipped')
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write
 
     steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-base-*
+        merge-multiple: true
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata for base
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base
+        tags: |
+          type=ref,event=branch
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base@sha256:%s ' *)
+
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base:${{ steps.meta.outputs.version }}
+
+  # ============================================
+  # RUNTIME IMAGE - Build per platform
+  # ============================================
+  build-runtime:
+    needs: [check-base, build-base, merge-base]
+    if: |
+      always() && 
+      (needs.check-base.outputs.should-build == 'false' || needs.merge-base.result == 'success')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -105,21 +231,81 @@ jobs:
           type=semver,pattern={{major}}
           type=raw,value=latest,enable={{is_default_branch}}
 
-    - name: Extract metadata for base
-      id: meta-base
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base
-        tags: |
-          type=raw,value=latest
-
-    - name: Build and push runtime image
-      uses: docker/build-push-action@v5
+    - name: Build and push runtime image by digest
+      id: build
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile.runtime
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
+        platforms: ${{ matrix.platform }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          BASE_IMAGE=${{ steps.meta-base.outputs.tags }}
+          BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-base:latest
+        outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+    - name: Export digest
+      if: github.event_name != 'pull_request'
+      run: |
+        mkdir -p ${{ runner.temp }}/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+    - name: Upload digest
+      if: github.event_name != 'pull_request'
+      uses: actions/upload-artifact@v4
+      with:
+        name: digests-runtime-${{ env.PLATFORM_PAIR }}
+        path: ${{ runner.temp }}/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  # ============================================
+  # RUNTIME IMAGE - Merge manifests
+  # ============================================
+  merge-runtime:
+    runs-on: ubuntu-latest
+    needs: build-runtime
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Download digests
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ runner.temp }}/digests
+        pattern: digests-runtime-*
+        merge-multiple: true
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Extract metadata for runtime
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+
+    - name: Create manifest list and push
+      working-directory: ${{ runner.temp }}/digests
+      run: |
+        docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+    - name: Inspect image
+      run: |
+        docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -48,11 +48,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install uv for Python package management
 RUN pip install --no-cache-dir uv
 
-# Download and install pre-built typst binary
+# Download and install pre-built typst binary (architecture-aware)
+ARG TARGETARCH
 RUN TYPST_VERSION=$(curl -s https://api.github.com/repos/typst/typst/releases/latest | grep -o '"tag_name": "[^"]*' | cut -d'"' -f4) && \
-    curl -L "https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz" | tar -xJ && \
-    mv typst-x86_64-unknown-linux-musl/typst /usr/local/bin/typst && \
-    rm -rf typst-x86_64-unknown-linux-musl
+    case "${TARGETARCH}" in \
+        amd64) TYPST_ARCH="x86_64" ;; \
+        arm64) TYPST_ARCH="aarch64" ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -L "https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-${TYPST_ARCH}-unknown-linux-musl.tar.xz" | tar -xJ && \
+    mv typst-${TYPST_ARCH}-unknown-linux-musl/typst /usr/local/bin/typst && \
+    rm -rf typst-${TYPST_ARCH}-unknown-linux-musl
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
This PR updates the github actions workflow to build the container both for amd64 and arm64 platforms.

---
## Why is it necessary ?
I tried to install the MCP on my Mac, after having copied the configuration for opencode, I was surprised to see that it failed executing. Pulling manually the image showed me that the image was only built for amd64 architecture.

This cloud be overcomed by adding `--platform=linux/amd64` to the mcp command, but it comes with two problems : 
- specific configuration to document for apple silicon macs
- non native execution

## Proposed solution with this PR
I updated the github actions workflow to build on a matrix of 2 machines
The workflow now does 2 base image build, wait for these two builds to complete and merge result in a single node, then build the two runtime images, then merge results and push the images for both amd64 and arm64 platforms.

---
## Tests
I tested these builds on my fork. You can find the images built for both architecture there. I tested the two images on my computer.
You can now use the normal configuration for opencode without friction.