### PR TITLE
Add import for sys module in server.py

### DIFF
--- a/server.py
+++ b/server.py
@@ -2,6 +2,7 @@ from mcp.server.fastmcp import FastMCP, Image
 import json
 import subprocess
 import os
+import sys
 import tempfile
 from PIL import Image as PILImage
 import io


### PR DESCRIPTION
https://github.com/johannesbrandenburger/typst-mcp/pull/8 added print to `sys.stderr`, but when running in VSCode on macOS, this causes tools `list_docs_chapters` and `get_docs_chapter` to throw an error `name 'sys' is not defined` (screenshot attached).

<img width="350" height="196" alt="image" src="https://github.com/user-attachments/assets/85386e44-2762-48db-98bf-f2cf3bc699f2" />

I was able to resolve this by adding a single line `import sys` to the top of `server.py`