### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The server provides the following tools:
   
 - Install Typst
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/johannesbrandenburger-typst-mcp).
+
 ## Running the Server
 
 ### Local Installation


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/johannesbrandenburger-typst-mcp).